### PR TITLE
Text change

### DIFF
--- a/syntax.md
+++ b/syntax.md
@@ -716,7 +716,6 @@ Appendix
 ========
 
 The syntax of rules is described by the following grammar in extended BNF.
-The meaning of the various elements of a rule is discussed in the text.
 
     rule ::= [ osc-pattern ] ':' midi-pattern
 


### PR DESCRIPTION
One more editing blunder, the text before the grammar still referred to explanations below, which doesn't make any sense now that it is in the appendix.